### PR TITLE
Add npmrc for publishing without login

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
This allows publishing with an `NPM_TOKEN` in your environment, meaning people or services do not have to login with the standard flow, 2FA, etc.