### PR TITLE
Use passed in tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/create-webpack-config",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/create-webpack-config",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A utility for creating webpack configs with common settings",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -255,7 +255,9 @@ function createWebpackConfig(options) {
       },
     },
     plugins: [
-      new ForkTsCheckerWebpackPlugin(),
+      new ForkTsCheckerWebpackPlugin({
+        tsconfig: path.resolve(process.cwd(), options.tsconfig),
+      }),
       new CircularDependencyPlugin({
         failOnError: true,
         exclude: /node_modules/,


### PR DESCRIPTION
Use passed in tsconfig when checking TS. Previously this was not being passed on so it was using the default tsconfig which for most projects meant it was type checking the tests when building for production which both added overhead and caused it to fail when dev dependencies were not present