### PR TITLE
Upgrade circular-dependency-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/create-webpack-config",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3440,9 +3440,9 @@
       }
     },
     "circular-dependency-plugin": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.0.tgz",
-      "integrity": "sha512-7p4Kn/gffhQaavNfyDFg7LS5S/UT1JAjyGd4UqR2+jzoYF02eDkj0Ec3+48TsIa4zghjLY87nQHIh/ecK9qLdw=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz",
+      "integrity": "sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ=="
     },
     "class-utils": {
       "version": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/create-webpack-config",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A utility for creating webpack configs with common settings",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/preset-typescript": "^7.12.1",
     "babel-loader": "^8.1.0",
     "babel-plugin-const-enum": "0.0.5",
-    "circular-dependency-plugin": "^5.2.0",
+    "circular-dependency-plugin": "^5.2.2",
     "core-js": "^3.6.5",
     "fork-ts-checker-webpack-plugin": "^5.2.1",
     "raf": "^3.4.1",


### PR DESCRIPTION
Apparently this plugin had some issues with webpack 5 (e.g. https://github.com/jantimon/html-webpack-plugin/issues/1541), but this upgrade should resolve them.