### PR TITLE
Add options to skip type and circular dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,28 @@ Add the following scripts to your `package.json`.
 }
 ```
 
+### Skipping type checking
+
+For builds that have already been type checked you may want to skip type checking. This can be done by enabling the `skipTypeChecking` option e.g.
+
+```js
+module.exports = createWebpackConfig({
+  // ...
+  skipTypeChecking: true,
+});
+```
+
+### Skipping circular dependency checks
+
+For builds that have already been checked for circular dependencies you may want to skip this step. This can be done by enabling the `skipCircularDependencyChecking` option e.g.
+
+```js
+module.exports = createWebpackConfig({
+  // ...
+  skipCircularDependencyChecking: true,
+});
+```
+
 ## Code of conduct
 
 For guidelines regarding the code of conduct when contributing to this repository please review [https://www.dabapps.com/open-source/code-of-conduct/](https://www.dabapps.com/open-source/code-of-conduct/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/create-webpack-config",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/create-webpack-config",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A utility for creating webpack configs with common settings",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -234,6 +234,26 @@ function createWebpackConfig(options) {
     },
   ].filter(rule => Boolean(rule));
 
+  const typeCheckerPlugins = options.skipTypeChecking
+    ? []
+    : [
+        new ForkTsCheckerWebpackPlugin({
+          typescript: {
+            configFile: path.resolve(process.cwd(), options.tsconfig),
+          },
+        }),
+      ];
+
+  const circularDependencyPlugins = options.skipCircularDependencyChecking
+    ? []
+    : [
+        new CircularDependencyPlugin({
+          failOnError: true,
+          exclude: /node_modules/,
+          cwd: CWD,
+        }),
+      ];
+
   return {
     performance: {
       hints: false,
@@ -255,16 +275,8 @@ function createWebpackConfig(options) {
       },
     },
     plugins: [
-      new ForkTsCheckerWebpackPlugin({
-        typescript: {
-          configFile: path.resolve(process.cwd(), options.tsconfig),
-        },
-      }),
-      new CircularDependencyPlugin({
-        failOnError: true,
-        exclude: /node_modules/,
-        cwd: CWD,
-      }),
+      ...typeCheckerPlugins,
+      ...circularDependencyPlugins,
       new EnvironmentPlugin(options.env || {}),
     ],
   };

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -527,4 +527,66 @@ describe('createWebpackConfig', () => {
       NODE_ENV: 'production',
     });
   });
+
+  it('should not include fork-ts-checker-webpack-plugin when skipTypeChecking is enabled', () => {
+    const config = createWebpackConfig({
+      input: 'test',
+      outDir: 'test',
+      tsconfig: 'test',
+      skipTypeChecking: false,
+    });
+
+    expect(config.plugins.length).toBe(3);
+
+    const noCheckConfig = createWebpackConfig({
+      input: 'test',
+      outDir: 'test',
+      tsconfig: 'test',
+      skipTypeChecking: true,
+    });
+
+    expect(noCheckConfig.plugins.length).toBe(2);
+  });
+
+  it('should not include circular-dependency-plugin when skipCircularDependencyChecking is enabled', () => {
+    const config = createWebpackConfig({
+      input: 'test',
+      outDir: 'test',
+      tsconfig: 'test',
+      skipCircularDependencyChecking: false,
+    });
+
+    expect(config.plugins.length).toBe(3);
+
+    const noCheckConfig = createWebpackConfig({
+      input: 'test',
+      outDir: 'test',
+      tsconfig: 'test',
+      skipCircularDependencyChecking: true,
+    });
+
+    expect(noCheckConfig.plugins.length).toBe(2);
+  });
+
+  it('should not include fork-ts-checker-webpack-plugin and circular-dependency-plugin when skipTypeChecking and skipCircularDependencyChecking are enabled', () => {
+    const config = createWebpackConfig({
+      input: 'test',
+      outDir: 'test',
+      tsconfig: 'test',
+      skipTypeChecking: false,
+      skipCircularDependencyChecking: false,
+    });
+
+    expect(config.plugins.length).toBe(3);
+
+    const noCheckConfig = createWebpackConfig({
+      input: 'test',
+      outDir: 'test',
+      tsconfig: 'test',
+      skipTypeChecking: true,
+      skipCircularDependencyChecking: true,
+    });
+
+    expect(noCheckConfig.plugins.length).toBe(1);
+  });
 });


### PR DESCRIPTION
Does what it says on the tin.

Why? Because by the time we're deploying to production these have already been checked multiple times. Even on staging they (will) have already been checked by the CI.